### PR TITLE
Issue 70 make cron hourly

### DIFF
--- a/cron/Dockerfile
+++ b/cron/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.8-slim
 
 RUN apt-get update && apt-get -y install -qq --force-yes cron
-RUN apt-get -y install vim
+RUN apt-get -y install vim nano jq
 RUN apt-get install gcc python3-dev -y
 
 WORKDIR /home
@@ -12,9 +12,9 @@ COPY requirements.txt find_dx_data.py ./
 
 RUN pip install -r requirements.txt
 
+# comment out a line in pam.d which stops crons running otherwise
+RUN sed -e '/session required pam_loginuid.so/ s/^#*/#/' -i /etc/pam.d/crond
+
 COPY crontab /etc/cron.d/crontab
 RUN chmod 0644 /etc/cron.d/crontab
 RUN crontab /etc/cron.d/crontab
-
-# comment out a line in pam.d which stops crons running otherwise
-RUN sed -e '/session required pam_loginuid.so/ s/^#*/#/' -i /etc/pam.d/crond

--- a/cron/Dockerfile
+++ b/cron/Dockerfile
@@ -13,7 +13,7 @@ COPY requirements.txt find_dx_data.py ./
 RUN pip install -r requirements.txt
 
 # comment out a line in pam.d which stops crons running otherwise
-RUN sed -e '/session required pam_loginuid.so/ s/^#*/#/' -i /etc/pam.d/cron
+RUN sed -e '/session    required     pam_loginuid.so/ s/^#*/#/' -i /etc/pam.d/cron
 
 COPY crontab /etc/cron.d/crontab
 RUN chmod 0644 /etc/cron.d/crontab

--- a/cron/Dockerfile
+++ b/cron/Dockerfile
@@ -16,3 +16,5 @@ COPY crontab /etc/cron.d/crontab
 RUN chmod 0644 /etc/cron.d/crontab
 RUN crontab /etc/cron.d/crontab
 
+# comment out a line in pam.d which stops crons running otherwise
+RUN sed -e '/session required pam_loginuid.so/ s/^#*/#/' -i /etc/pam.d/crond

--- a/cron/Dockerfile
+++ b/cron/Dockerfile
@@ -13,7 +13,7 @@ COPY requirements.txt find_dx_data.py ./
 RUN pip install -r requirements.txt
 
 # comment out a line in pam.d which stops crons running otherwise
-RUN sed -e '/session required pam_loginuid.so/ s/^#*/#/' -i /etc/pam.d/crond
+RUN sed -e '/session required pam_loginuid.so/ s/^#*/#/' -i /etc/pam.d/cron
 
 COPY crontab /etc/cron.d/crontab
 RUN chmod 0644 /etc/cron.d/crontab

--- a/cron/crontab
+++ b/cron/crontab
@@ -1,4 +1,4 @@
 # start cron
 0 2 * * * rm -rf /home/tmp/* && echo "`date +\%Y\%m\%d-\%H:\%M:\%S` tmp folder cleared" >> /home/log/ga-cron.log 2>&1
-0 2 * * * /usr/local/bin/python -u /home/find_dx_data.py >> /home/log/ga-cron.log 2>&1 && echo "`date +\%Y\%m\%d-\%H:\%M:\%S` sample file updated" >> /home/log/ga-cron.log 2>&1
+0 * * * * /usr/local/bin/python -u /home/find_dx_data.py >> /home/log/ga-cron.log 2>&1 && echo "`date +\%Y\%m\%d-\%H:\%M:\%S` sample file updated" >> /home/log/ga-cron.log 2>&1
 # end cron

--- a/cron/find_dx_data.py
+++ b/cron/find_dx_data.py
@@ -414,6 +414,6 @@ if __name__ == "__main__":
 
     if dx_login(DNANEXUS_TOKEN, SLACK_TOKEN, DEBUG):
         find_dx_bams(get_002_projects())
-    
+
     et = time.time()
     print(f"Execution time: {et-st} seconds")


### PR DESCRIPTION
Changes:
- Make crontab run hourly by default (https://github.com/eastgenomics/Genetics_Ark/issues/70)
- Modify Dockerfile to remove a troublesome line in /etc/pam.d/cron, which prevents cron running in container (https://github.com/eastgenomics/Genetics_Ark/issues/72)
- Install nano and jq in the cron container for ease of troubleshooting

Test setup:
- Built image from cron Dockerfile, transferred to dev environment via DNAnexus
- Changed docker-compose.yml to use this test version of cron (version tag 'issue_70')
- Ran 'podman-compose up -d' and exec'd into the cron container

Tests:
- Typing 'nano' and 'vim' gives help lines - they have installed
- The /etc/pam.d/cron offending line is commented out without manual intervention
- When the cron run time is changed to the very near future and the cron service is restarted, the cron runs successfully

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/Genetics_Ark/76)
<!-- Reviewable:end -->
