### PR TITLE
Update compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ staticfiles
 reference
 .vscode
 .DS_Store
+config.dev.txt
+config.prod.txt
+*.config.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,10 @@
 # config.py must NOT be in version control
 django_example/config.py
 env
+.env
 __pycache__
 logs/*
 tmp/*
-.env
 DNAnexus_to_igv/jsons/*
 staticfiles
 reference
@@ -12,4 +12,7 @@ reference
 .DS_Store
 config.dev.txt
 config.prod.txt
+config.*.txt
 *.config.txt
+# avoid incorporating zipped Docker image files
+*.gz

--- a/cron/Dockerfile
+++ b/cron/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.8-slim
 
 RUN apt-get update && apt-get -y install -qq --force-yes cron
-RUN apt-get -y install vim nano jq
+RUN apt-get -y install vim nano jq procps
 RUN apt-get install gcc python3-dev -y
 
 WORKDIR /home

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       dockerfile: web.Dockerfile
     restart: always
     env_file:
-      - ${GA_PATH}/.env
+      - ${GA_CONFIG_PATH}
     volumes:
       - igv_volume:/home/ga/DNAnexus_to_igv/jsons # read updated BAM json file
       - static_volume:/home/ga/staticfiles # staticfiles
@@ -32,12 +32,6 @@ services:
       - primer_volume:/home/tmp # to clear generated pdfs
       - igv_volume:/home/jsons # to update the sample json
       - ${LOG_PATH}:/home/log # cron job logging
-    environment:
-      - DNANEXUS_TOKEN=${DNANEXUS_TOKEN}
-      - PROJECT_CNVS=${PROJECT_CNVS}
-      - DEV_PROJECT_NAME=${DEV_PROJECT_NAME}
-      - SLACK_TOKEN=${SLACK_TOKEN}
-      - GENETIC_DEBUG=${GENETIC_DEBUG}
   geneticsnginx:
     container_name: genetics-ark-nginx
     image: nginx:1.23
@@ -51,9 +45,6 @@ services:
       - ${GA_PATH}/nginx:/etc/nginx/conf.d # nginx config
     expose:
       - 8002
-    environment:
-      - VIRTUAL_HOST=${VIRTUAL_HOST}
-      - VIRTUAL_PATH=${VIRTUAL_PATH}
     depends_on:
       - geneticsweb
   redis:
@@ -72,7 +63,7 @@ services:
     command: python manage.py qcluster
     restart: always
     env_file:
-      - ${GA_PATH}/.env
+      - ${GA_CONFIG_PATH}
     volumes:
       - primer_volume:/home/primer_designer/output # zip generated primer designer PDFs
       - ${REF_PATH}:/reference_files # refs for primer designer
@@ -85,7 +76,7 @@ services:
     ports:
       - 3307:3308
     env_file:
-      - ${GA_PATH}/.env
+      - ${GA_CONFIG_PATH}
     volumes:
       - genetics_db:/var/lib/mysql
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,30 +1,29 @@
 version: '2.6'
 
 # PORT for web application, nginx, redis and database will change based on Port documentation on Dev and Prod server
-
 services:
   geneticsweb:
     container_name: genetics-ark-web
-    image: genetics-ark-web:2.0.1
+    image: genetics-ark-web:2.0.3
+    command: bash -c "python manage.py collectstatic --noinput && gunicorn ga_core.wsgi:application --bind :8003 --timeout 300 --workers 2 --threads 4"
     platform: linux/amd64
     build:
       dockerfile: web.Dockerfile
-    command: bash -c "python manage.py collectstatic --noinput && gunicorn ga_core.wsgi:application --bind :8003 --timeout 300 --workers 2 --threads 4"
     restart: always
     env_file:
       - /Users/jason/Github/Genetics_Ark/.env
     volumes:
       - igv_volume:/home/ga/DNAnexus_to_igv/jsons # read updated BAM json file
       - static_volume:/home/ga/staticfiles # staticfiles
-      - /Users/jason/Github/Genetics_Ark/logs # write logging
+      - /Users/jason/Github/Genetics_Ark/logs:/home/ga/logs # write logging
       - /Users/jason/Github/Genetics_Ark/reference:/reference_files # refs for primer designer
     expose:
-      - 8003 # expose port within the container ONLY
+      - 8000 # expose port within the container ONLY
     depends_on:
       - geneticsdb
   geneticscron:
     container_name: genetics-ark-cron
-    image: genetics-ark-cron:2.0.1
+    image: genetics-ark-cron:2.0.3
     platform: linux/amd64
     restart: always
     build: ./cron
@@ -54,16 +53,16 @@ services:
     depends_on:
       - geneticsweb
   redis:
-    # container_name: genetics-ark-redis
-    # platform: linux/amd64
+    container_name: genetics-ark-redis
     image: redis:7-alpine
+    platform: linux/amd64
     restart: always
     ports:
       - 6379:6379
   geneticsdjangoq:
-    image: genetics-ark-djangoq:2.0.1
-    platform: linux/amd64
     container_name: genetics-ark-djangoq
+    image: genetics-ark-djangoq:2.0.3
+    platform: linux/amd64
     build:
       dockerfile: primer.Dockerfile
     command: python manage.py qcluster
@@ -76,8 +75,8 @@ services:
     depends_on:
       - redis
   geneticsdb:
-    container_name: genetics-ark-db
     # platform: linux/amd64
+    container_name: genetics-ark-db
     image: mysql:8
     ports:
       - 3307:3308
@@ -91,7 +90,6 @@ volumes:
   primer_volume:
   igv_volume:
   genetics_db:
-
 
 networks:
   default:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,12 +11,12 @@ services:
       dockerfile: web.Dockerfile
     restart: always
     env_file:
-      - /Users/jason/Github/Genetics_Ark/.env
+      - ${GA_PATH}/.env
     volumes:
       - igv_volume:/home/ga/DNAnexus_to_igv/jsons # read updated BAM json file
       - static_volume:/home/ga/staticfiles # staticfiles
-      - /Users/jason/Github/Genetics_Ark/logs:/home/ga/logs # write logging
-      - /Users/jason/Github/Genetics_Ark/reference:/reference_files # refs for primer designer
+      - ${LOG_PATH}:/home/ga/logs # write logging
+      - ${REF_PATH}:/reference_files # refs for primer designer
     expose:
       - 8001 # expose port within the container ONLY
     depends_on:
@@ -31,7 +31,7 @@ services:
     volumes:
       - primer_volume:/home/tmp # to clear generated pdfs
       - igv_volume:/home/jsons # to update the sample json
-      - /Users/jason/Github/Genetics_Ark/logs:/home/log # cron job logging
+      - ${LOG_PATH}:/home/log # cron job logging
     environment:
       - DNANEXUS_TOKEN=${DNANEXUS_TOKEN}
       - PROJECT_CNVS=${PROJECT_CNVS}
@@ -44,16 +44,16 @@ services:
     platform: linux/amd64
     restart: always
     volumes:
-      - /Users/jason/Github/Genetics_Ark/reference:/reference_files # serve igv references through nginx
+      - ${REF_PATH}:/reference_files # serve igv references through nginx
       - primer_volume:/tmp # zip generated primer designer PDFs
       - static_volume:/staticfiles # serve staticfiles
-      - /Users/jason/Github/Genetics_Ark/logs:/home/ga/log # logging for nginx
-      - /Users/jason/Github/Genetics_Ark/nginx:/etc/nginx/conf.d # nginx config
+      - ${LOG_PATH}:/home/ga/log # logging for nginx
+      - ${GA_PATH}/nginx:/etc/nginx/conf.d # nginx config
     expose:
       - 8002
     environment:
-      - VIRTUAL_HOST=localhost
-      - VIRTUAL_PATH=/genetics_ark
+      - VIRTUAL_HOST=${VIRTUAL_HOST}
+      - VIRTUAL_PATH=${VIRTUAL_PATH}
     depends_on:
       - geneticsweb
   redis:
@@ -72,10 +72,10 @@ services:
     command: python manage.py qcluster
     restart: always
     env_file:
-      - /Users/jason/Github/Genetics_Ark/.env
+      - ${GA_PATH}/.env
     volumes:
       - primer_volume:/home/primer_designer/output # zip generated primer designer PDFs
-      - /Users/jason/Github/Genetics_Ark/reference:/reference_files # refs for primer designer
+      - ${REF_PATH}:/reference_files # refs for primer designer
     depends_on:
       - redis
   geneticsdb:
@@ -85,7 +85,7 @@ services:
     ports:
       - 3307:3308
     env_file:
-      - /Users/jason/Github/Genetics_Ark/.env
+      - ${GA_PATH}/.env
     volumes:
       - genetics_db:/var/lib/mysql
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.6'
+version: '2.0'
 
 # PORT for web application, nginx, redis and database will change based on Port documentation on Dev and Prod server
 services:
@@ -18,7 +18,7 @@ services:
       - /Users/jason/Github/Genetics_Ark/logs:/home/ga/logs # write logging
       - /Users/jason/Github/Genetics_Ark/reference:/reference_files # refs for primer designer
     expose:
-      - 8000 # expose port within the container ONLY
+      - 8001 # expose port within the container ONLY
     depends_on:
       - geneticsdb
   geneticscron:
@@ -28,12 +28,16 @@ services:
     restart: always
     build: ./cron
     command: bash -c "printenv > /etc/environment && cron -f"
-    env_file:
-      - /Users/jason/Github/Genetics_Ark/.env
     volumes:
       - primer_volume:/home/tmp # to clear generated pdfs
       - igv_volume:/home/jsons # to update the sample json
       - /Users/jason/Github/Genetics_Ark/logs:/home/log # cron job logging
+    environment:
+      - DNANEXUS_TOKEN=${DNANEXUS_TOKEN}
+      - PROJECT_CNVS=${PROJECT_CNVS}
+      - DEV_PROJECT_NAME=${DEV_PROJECT_NAME}
+      - SLACK_TOKEN=${SLACK_TOKEN}
+      - GENETIC_DEBUG=${GENETIC_DEBUG}
   geneticsnginx:
     container_name: genetics-ark-nginx
     image: nginx:1.23

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.0'
+version: '3.3'
 
 # PORT for web application, nginx, redis and database will change based on Port documentation on Dev and Prod server
 services:
@@ -18,7 +18,7 @@ services:
       - ${LOG_PATH}:/home/ga/logs # write logging
       - ${REF_PATH}:/reference_files # refs for primer designer
     expose:
-      - 8001 # expose port within the container ONLY
+      - 8000 # expose port within the container ONLY
     depends_on:
       - geneticsdb
   geneticscron:
@@ -44,7 +44,7 @@ services:
       - ${LOG_PATH}:/home/ga/log # logging for nginx
       - ${GA_PATH}/nginx:/etc/nginx/conf.d # nginx config
     expose:
-      - 8002
+      - 8001
     depends_on:
       - geneticsweb
   redis:
@@ -74,7 +74,7 @@ services:
     container_name: genetics-ark-db
     image: mysql:8
     ports:
-      - 3307:3308
+      - 3308:3308
     env_file:
       - ${GA_CONFIG_PATH}
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   geneticsweb:
     container_name: genetics-ark-web
     image: genetics-ark-web:2.0.3
-    command: bash -c "python manage.py collectstatic --noinput && gunicorn ga_core.wsgi:application --bind :8003 --timeout 300 --workers 2 --threads 4"
+    command: bash -c "python manage.py collectstatic --noinput && gunicorn ga_core.wsgi:application --bind :8000 --timeout 300 --workers 2 --threads 4"
     platform: linux/amd64
     build:
       dockerfile: web.Dockerfile
@@ -18,7 +18,7 @@ services:
       - ${LOG_PATH}:/home/ga/logs # write logging
       - ${REF_PATH}:/reference_files # refs for primer designer
     expose:
-      - 8000 # expose port within the container ONLY
+      - 8001 # expose port within the container ONLY
     depends_on:
       - geneticsdb
   geneticscron:
@@ -44,7 +44,7 @@ services:
       - ${LOG_PATH}:/home/ga/log # logging for nginx
       - ${GA_PATH}/nginx:/etc/nginx/conf.d # nginx config
     expose:
-      - 8001
+      - 8002
     depends_on:
       - geneticsweb
   redis:
@@ -73,8 +73,8 @@ services:
     # platform: linux/amd64
     container_name: genetics-ark-db
     image: mysql:8
-    ports:
-      - 3308:3308
+    expose:
+      - 3306
     env_file:
       - ${GA_CONFIG_PATH}
     volumes:

--- a/example.config.txt
+++ b/example.config.txt
@@ -1,0 +1,71 @@
+
+# General Django settings - including Django secret key, whether to run in
+# debug or not, and production versus development/debug hosts 
+# VIRTUAL_HOST should be the base URL to run on, VIRTUAL_PATH the suffix
+
+SECRET_KEY=
+GENETIC_DEBUG=
+CSRF_TRUSTED_ORIGINS=http://localhost
+PROD_HOST=localhost
+DEBUG_HOST=
+
+VIRTUAL_HOST=
+VIRTUAL_PATH=/genetics_ark
+
+
+# For the Primer Designer output PDF - control the displayed SNP file text, displayed version,
+# and download link for PDF results
+
+PRIMER37_TEXT=Common SNP annotation: A common SNP is one that has (minor) allele frequency higher than or equal to 1% in the gnomad database version 2.0.1
+PRIMER38_TEXT=Common SNP annotation: A common SNP is one that has (minor) allele frequency higher than or equal to 1% in the gnomad database version 3.1.2
+PRIMER_VERSION=2.0.2
+PRIMER_DOWNLOAD=http://localhost:80/genetics_ark
+
+
+# Variables for authorising log-ins using LDAP. LDAP_CONF is the base DN. 
+
+BIND_DN=
+BIND_PASSWORD=
+AUTH_LDAP_SERVER_URI=
+LDAP_CONF=
+
+
+# Variables for the GA database
+
+DB_NAME=
+DB_USERNAME=
+DB_PASSWORD=
+DB_PORT=
+MYSQL_ROOT_PASSWORD=
+
+
+# Variables needed for IGV/ga_core and find_dx_data
+# DEV_PROJECT_NAME is the name of dev project 003, PROJECT_CNVS is the CNV project IDs
+
+DEV_PROJECT_NAME=
+PROJECT_CNVS=
+
+
+# Variables for using IGV - all the below should be set to URLs to the named resource
+
+GENOMES=
+
+FASTA_37= 
+FASTA_IDX_37=
+CYTOBAND_37=
+REFSEQ_37=
+REFSEQ_INDEX_37=
+
+FASTA_38=
+FASTA_IDX_38=
+CYTOBAND_38=
+REFSEQ_38=
+REFSEQ_INDEX_38=
+
+
+# external services - tokens for accessing DNAnexus and Slack,
+# and the URL for the bioinformatics service desk 
+
+DNANEXUS_TOKEN=
+SLACK_TOKEN=
+GRID_SERVICE_DESK=

--- a/example.config.txt
+++ b/example.config.txt
@@ -4,7 +4,7 @@
 # VIRTUAL_HOST should be the base URL to run on, VIRTUAL_PATH the suffix
 
 SECRET_KEY=
-GENETIC_DEBUG=
+GENETIC_DEBUG= #only add 'True' if you're wanting to use in Debug mode
 CSRF_TRUSTED_ORIGINS=http://localhost
 PROD_HOST=localhost
 DEBUG_HOST=
@@ -17,6 +17,7 @@ VIRTUAL_PATH=/genetics_ark
 
 REF_37=
 SNP_37=
+
 REF_38=
 SNP_38=
 
@@ -26,7 +27,9 @@ SNP_38=
 
 PRIMER37_TEXT=Common SNP annotation: A common SNP is one that has (minor) allele frequency higher than or equal to 1% in the gnomad database version 2.0.1
 PRIMER38_TEXT=Common SNP annotation: A common SNP is one that has (minor) allele frequency higher than or equal to 1% in the gnomad database version 3.1.2
+
 PRIMER_VERSION=2.0.2
+
 PRIMER_DOWNLOAD=http://localhost:80/genetics_ark
 
 
@@ -44,7 +47,9 @@ DB_NAME=
 DB_USERNAME=
 DB_PASSWORD=
 DB_PORT=
+
 MYSQL_ROOT_PASSWORD=
+MYSQL_DATABASE=
 
 
 # Variables needed for IGV/ga_core and find_dx_data

--- a/example.config.txt
+++ b/example.config.txt
@@ -13,6 +13,14 @@ VIRTUAL_HOST=
 VIRTUAL_PATH=/genetics_ark
 
 
+# Paths for Primer Designer - FASTA reference files, and gnomAD VCFs for SNPs
+
+REF_37=
+SNP_37=
+REF_38=
+SNP_38=
+
+
 # For the Primer Designer output PDF - control the displayed SNP file text, displayed version,
 # and download link for PDF results
 

--- a/example.env
+++ b/example.env
@@ -1,28 +1,33 @@
-PRIMER_VERSION=2.0.1
 
-REF_37=/reference_files/grch37/hs37d5.fa
-SNP_37=/reference_files/grch37/gnomad.genomes.r2.0.1.sites.noVEP.AF-0.01.infoRemoved.vcf.gz
 
-REF_38=/reference_files/grch38/GCA_000001405.15_GRCh38_no_alt_analysis_set_plus_hs38d1_maskedGRC_exclusions_v2_no_chr.fa
-SNP_38=/reference_files/grch38/gnomad.genomes.v3.1.2.AF.0.01.info.removed.no_chr.vcf.gz
-
-PRIMER37_TEXT=Common SNP annotation: A common SNP is one that has (minor) allele frequency higher than or equal to 1% in the gnomad database version 2.0.1
-PRIMER38_TEXT=Common SNP annotation: A common SNP is one that has (minor) allele frequency higher than or equal to 1% in the gnomad database version 3.1.2
+# General Django settings - including Django secret key, whether to run in
+debug or not, and production versus development/debug hosts 
 
 SECRET_KEY=
 GENETIC_DEBUG=
 CSRF_TRUSTED_ORIGINS=http://localhost
+PROD_HOST=localhost
+DEBUG_HOST=
+
+
+# For the Primer Designer output PDF - control the  displayed SNP file text, displayed version,
+# and download link for PDF results
+
+PRIMER37_TEXT=Common SNP annotation: A common SNP is one that has (minor) allele frequency higher than or equal to 1% in the gnomad database version 2.0.1
+PRIMER38_TEXT=Common SNP annotation: A common SNP is one that has (minor) allele frequency higher than or equal to 1% in the gnomad database version 3.1.2
+PRIMER_VERSION=2.0.2
 PRIMER_DOWNLOAD=http://localhost:80/genetics_ark
 
-DNANEXUS_TOKEN=
+
+# Variables for authorising log-ins using LDAP. LDAP_CONF is the base DN. 
 
 BIND_DN=
 BIND_PASSWORD=
 AUTH_LDAP_SERVER_URI=
 LDAP_CONF=
 
-PROD_HOST=localhost
-DEBUG_HOST=
+
+# Variables for the GA database
 
 DB_NAME=
 DB_USERNAME=
@@ -31,9 +36,18 @@ DB_PORT=
 MYSQL_ROOT_PASSWORD=
 
 
+# Variables needed for IGV/ga_core and find_dx_data
+# DEV_PROJECT_NAME is the name of dev project 003, PROJECT_CNVS is the CNV project IDs
+
+DEV_PROJECT_NAME=
+PROJECT_CNVS=
+
+
+# Variables for using IGV - all the below should be set to URLs to the named resource
+
 GENOMES=
 
-FASTA_37=
+FASTA_37= 
 FASTA_IDX_37=
 CYTOBAND_37=
 REFSEQ_37=
@@ -45,9 +59,10 @@ CYTOBAND_38=
 REFSEQ_38=
 REFSEQ_INDEX_38=
 
-DEV_PROJECT_NAME=
-PROJECT_CNVS=
 
+# external services - tokens for accessing DNAnexus and Slack,
+# and the URL for the bioinformatics service desk 
+
+DNANEXUS_TOKEN=
 SLACK_TOKEN=
-
 GRID_SERVICE_DESK=

--- a/example.env
+++ b/example.env
@@ -1,4 +1,11 @@
 
+# Directories - paths to the Genetics Ark parent directory, the parent
+# directory for reference files, and the parent directory for log files
+
+GA_PATH=/home/my_name/Genetics_Ark
+REF_PATH=/wc/references
+LOG_PATH=/home/my_name/logs
+
 
 # General Django settings - including Django secret key, whether to run in
 # debug or not, and production versus development/debug hosts 
@@ -12,12 +19,6 @@ DEBUG_HOST=
 
 VIRTUAL_HOST=
 VIRTUAL_PATH=/genetics_ark
-
-
-# GA_PATH gives the local path to the parent directory that the Genetics Ark 
-# docker-compose and mounted drives are being stored in
-
-GA_PATH=/home/my_name/Genetics_Ark
 
 
 # For the Primer Designer output PDF - control the displayed SNP file text, displayed version,

--- a/example.env
+++ b/example.env
@@ -1,7 +1,8 @@
 
 
 # General Django settings - including Django secret key, whether to run in
-debug or not, and production versus development/debug hosts 
+# debug or not, and production versus development/debug hosts 
+# VIRTUAL_HOST should be the base URL to run on, VIRTUAL_PATH the suffix
 
 SECRET_KEY=
 GENETIC_DEBUG=
@@ -9,8 +10,17 @@ CSRF_TRUSTED_ORIGINS=http://localhost
 PROD_HOST=localhost
 DEBUG_HOST=
 
+VIRTUAL_HOST=
+VIRTUAL_PATH=/genetics_ark
 
-# For the Primer Designer output PDF - control the  displayed SNP file text, displayed version,
+
+# GA_PATH gives the local path to the parent directory that the Genetics Ark 
+# docker-compose and mounted drives are being stored in
+
+GA_PATH=/home/my_name/Genetics_Ark
+
+
+# For the Primer Designer output PDF - control the displayed SNP file text, displayed version,
 # and download link for PDF results
 
 PRIMER37_TEXT=Common SNP annotation: A common SNP is one that has (minor) allele frequency higher than or equal to 1% in the gnomad database version 2.0.1

--- a/example.env
+++ b/example.env
@@ -1,6 +1,6 @@
 
 # Directories - paths to the main config text file, the Genetics Ark parent directory, 
-# the path to the the parent directory for reference files, and the parent directory for log files
+#  the parent directory for reference files, and the parent directory for log files
 
 GA_CONFIG_PATH=/home/my_name/config.txt
 GA_PATH=/home/my_name/Genetics_Ark

--- a/example.env
+++ b/example.env
@@ -1,79 +1,8 @@
 
-# Directories - paths to the Genetics Ark parent directory, the parent
-# directory for reference files, and the parent directory for log files
+# Directories - paths to the main config text file, the Genetics Ark parent directory, 
+# the path to the the parent directory for reference files, and the parent directory for log files
 
+GA_CONFIG_PATH=/home/my_name/config.txt
 GA_PATH=/home/my_name/Genetics_Ark
 REF_PATH=/wc/references
 LOG_PATH=/home/my_name/logs
-
-
-# General Django settings - including Django secret key, whether to run in
-# debug or not, and production versus development/debug hosts 
-# VIRTUAL_HOST should be the base URL to run on, VIRTUAL_PATH the suffix
-
-SECRET_KEY=
-GENETIC_DEBUG=
-CSRF_TRUSTED_ORIGINS=http://localhost
-PROD_HOST=localhost
-DEBUG_HOST=
-
-VIRTUAL_HOST=
-VIRTUAL_PATH=/genetics_ark
-
-
-# For the Primer Designer output PDF - control the displayed SNP file text, displayed version,
-# and download link for PDF results
-
-PRIMER37_TEXT=Common SNP annotation: A common SNP is one that has (minor) allele frequency higher than or equal to 1% in the gnomad database version 2.0.1
-PRIMER38_TEXT=Common SNP annotation: A common SNP is one that has (minor) allele frequency higher than or equal to 1% in the gnomad database version 3.1.2
-PRIMER_VERSION=2.0.2
-PRIMER_DOWNLOAD=http://localhost:80/genetics_ark
-
-
-# Variables for authorising log-ins using LDAP. LDAP_CONF is the base DN. 
-
-BIND_DN=
-BIND_PASSWORD=
-AUTH_LDAP_SERVER_URI=
-LDAP_CONF=
-
-
-# Variables for the GA database
-
-DB_NAME=
-DB_USERNAME=
-DB_PASSWORD=
-DB_PORT=
-MYSQL_ROOT_PASSWORD=
-
-
-# Variables needed for IGV/ga_core and find_dx_data
-# DEV_PROJECT_NAME is the name of dev project 003, PROJECT_CNVS is the CNV project IDs
-
-DEV_PROJECT_NAME=
-PROJECT_CNVS=
-
-
-# Variables for using IGV - all the below should be set to URLs to the named resource
-
-GENOMES=
-
-FASTA_37= 
-FASTA_IDX_37=
-CYTOBAND_37=
-REFSEQ_37=
-REFSEQ_INDEX_37=
-
-FASTA_38=
-FASTA_IDX_38=
-CYTOBAND_38=
-REFSEQ_38=
-REFSEQ_INDEX_38=
-
-
-# external services - tokens for accessing DNAnexus and Slack,
-# and the URL for the bioinformatics service desk 
-
-DNANEXUS_TOKEN=
-SLACK_TOKEN=
-GRID_SERVICE_DESK=

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,5 +1,5 @@
 upstream ga {
-    server geneticsweb:8003 fail_timeout=0; # the PORT will change when deploying to Prod or Dev depending on the Port Documentation
+    server geneticsweb:8000 fail_timeout=0; # the PORT will change when deploying to Prod or Dev depending on the Port Documentation
 }
 
 server {

--- a/primer.Dockerfile
+++ b/primer.Dockerfile
@@ -1,7 +1,7 @@
 FROM primer-designer:2.0.2
 
 RUN apt-get update -y
-RUN apt-get install -y build-essential gcc python3-dev libldap2-dev libsasl2-dev ldap-utils tox lcov valgrind vim nano jq
+RUN apt-get install -y build-essential gcc python3-dev libldap2-dev libsasl2-dev ldap-utils tox lcov valgrind vim nano jq procps
 
 
 WORKDIR /home/ga

--- a/primer.Dockerfile
+++ b/primer.Dockerfile
@@ -1,7 +1,8 @@
 FROM primer-designer:2.0.2
 
 RUN apt-get update -y
-RUN apt-get install -y build-essential gcc python3-dev libldap2-dev libsasl2-dev ldap-utils tox lcov valgrind
+RUN apt-get install -y build-essential gcc python3-dev libldap2-dev libsasl2-dev ldap-utils tox lcov valgrind vim nano jq
+
 
 WORKDIR /home/ga
 

--- a/readme.md
+++ b/readme.md
@@ -76,7 +76,7 @@ Redis as queue broker
 MySQL database
 
 ## Environments
-View the 'example.env' file for descriptions of the required environment variables, which should be stored in a '*.env' file locally.
+View the 'example.env' file for descriptions of the required environment variables, which should be stored in a '.env' file locally. .env files must not be version-controlled.
 
 ## Current Apps
 

--- a/readme.md
+++ b/readme.md
@@ -19,10 +19,13 @@ Genetics Ark allows igv searching for BAM or CNV samples (login required)
 
   
 ## Setup and Running 
+
 Genetics Ark requires 2 local files containing environment variables:
 - A small `.env` file, kept in the same directory as your docker-compose.yml file. This only contains paths to mounted volumes, plus the path to the main config.txt file, given by GA_CONFIG_PATH. By adjusting this, the user can change their main config path for the docker-compose.yml without having to edit the docker-compose.yml directly. See the example.env.
 - A 'config.txt' file, which contains the majority of the environment variables. See example.config.txt for annotations.
-  
+
+In addition, you'll need to check that nginx/nginx.conf displays the correct ports for Genetics Ark. In the upstream ga{} section, ensure the port matches the one for genetics-ark-web.
+
 
 ### docker-compose
 

--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,7 @@ Ensure the following environment variables are correct:
 You must also run a server, with `python manage.py runserver`
 
 ### Running in production
-Ensure `GENETIC_DEBUG` is not in config file to run in production mode
+Ensure `GENETIC_DEBUG` is not in config file, to run in production mode
 ```
 docker compose build
 docker compose up db -d # start db first and create a database named genetics

--- a/readme.md
+++ b/readme.md
@@ -20,29 +20,32 @@ Genetics Ark allows igv searching for BAM or CNV samples (login required)
   
 ## Setup and Running 
 
-Genetics Ark requires environment variables in a `config.txt` or `.env` file (see example.env)
+Genetics Ark requires environment variables in a `.env` file kept in the same directory as your docker-compose.yml file. See the example.env.
   
-Edit `env_file` in `docker-compose.yml` to point to your `.env` file
 
 ### docker-compose
 
 #### cron
-- Edit `crontab` file to tweak cron schedule
+- By default, find_dx_data.py runs hourly, and checks for new samples in DNAnexus which can be made available to IGV. A script which clears out a temporary directory runs every morning at 2am.
+- Edit `crontab` file to tweak cron schedule.
 ```
 # start cron
 0 2 * * * rm -rf /home/tmp/* && echo "`date +\%Y\%m\%d-\%H:\%M:\%S` tmp folder cleared" >> /home/log/ga-cron.log 2>&1
-0 2 * * * /usr/local/bin/python -u /home/find_dx_data.py >> /home/log/ga-cron.log 2>&1
+0 * * * * /usr/local/bin/python -u /home/find_dx_data.py >> /home/log/ga-cron.log 2>&1
 # end cron
 ```
-Check schduled cron is running by accessing cron container `docker exec -it <container id> bash` then `crontab -l`. Sometimes cron ran into [pam security issue](https://stackoverflow.com/questions/21926465/issues-running-cron-in-docker-on-different-hosts). 
+Check schduled cron is running by accessing cron container `docker exec -it <container id> bash` then `crontab -l`.
 
-All cron run log will be stored in cron container `/home/log/cron.log`
+All cron run logs will be stored in cron container `/home/log/cron.log`
 
 ### Running in local system
+Ensure the following environment variables are correct:
+
 - change logging location in `ga_core/settings.py`
 - change database setting to localhost database
 - change redis setting to localhost redis
-- run server `python manage.py runserver`
+
+You must also run a server, with `python manage.py runserver`
 
 ### Running in production
 Ensure `GENETIC_DEBUG` is not in config file to run in production mode
@@ -73,61 +76,7 @@ Redis as queue broker
 MySQL database
 
 ## Environments
-```
-PRIMER_VERSION - primer designer version to be displayed in output PDF
-
-REF_37 - directory pathway (docker) to grch37 reference
-SNP_37 - directory pathway (docker) to snp37 gnomad file
-
-REF_38 - directory pathway (docker) to grch38 reference
-SNP_38 - directory pathway (docker) to snp38 gnomad file
-
-PRIMER37_TEXT - text displayed in output primer PDF for grch37 snp file
-PRIMER38_TEXT - text displayed in output primer PDF for grch38 snp file
-
-SECRET_KEY - django secret key
-GENETIC_DEBUG - whether to run in debug or not
-CSRF_TRUSTED_ORIGINS - hostname for csrf form submission
-PRIMER_DOWNLOAD - primer PDF download link (e.g. http://localhost:80/genetics_ark)
-
-DNANEXUS_TOKEN - DNANexus auth token
-
-BIND_DN - ldap bind username
-BIND_PASSWORD - ldap bind password
-AUTH_LDAP_SERVER_URI - ldap uri
-LDAP_CONF - ldap base_dn
-
-PROD_HOST - production host (django)
-DEBUG_HOST - debug host (django) e.g. *
-
-DB_NAME - db name
-DB_USERNAME - db username
-DB_PASSWORD - db password
-DB_PORT - db port
-MYSQL_ROOT_PASSWORD - mysql root password
-
-
-GENOMES - url to genomes.json used by igv
-
-FASTA_37 - url to fasta37 used by igv
-FASTA_IDX_37 -url to fasta37_index used by igv
-CYTOBAND_37 - url to cytoband37 used by igv
-REFSEQ_37 - url to refseq37 used by igv
-REFSEQ_INDEX_37 - url to refseq37_index used by igv
-
-FASTA_38 - url to fasta38 used by igv
-FASTA_IDX_38 - url to fasta38_index used by igv
-CYTOBAND_38 - url to cytoband38 used by igv
-REFSEQ_38 - url to refseq38 used by igv
-REFSEQ_INDEX_38 - url to refseq38_index used by igv
-
-DEV_PROJECT_NAME - name of dev project 003
-PROJECT_CNVS - project-id of cnvs projects
-
-SLACK_TOKEN - slack auth token
-
-GRID_SERVICE_DESK - url for bioinformatics service desk
-```
+View the 'example.env' file for descriptions of the required environment variables, which should be stored in a '*.env' file locally.
 
 ## Current Apps
 
@@ -136,3 +85,5 @@ GRID_SERVICE_DESK - url for bioinformatics service desk
  - **DNAnexus_to_igv**: App to link samples stored in the DNAnexus cloud platform with Genetics Ark. On searching for a sample (BAM or CNV), if it is found within a 002 sequencing project within DNAnexus (for BAM) or in `PROJECT_CNVS` (for CNVs), download urls are provided for the file and its index file to load within IGV installed on a PC. A link to stream the file directly to IGV.js is also provided. cron container will periodically run find_dx_data.py to update the `.json` of samples
   
 ## Apps in Development:
+
+N/A

--- a/readme.md
+++ b/readme.md
@@ -19,8 +19,9 @@ Genetics Ark allows igv searching for BAM or CNV samples (login required)
 
   
 ## Setup and Running 
-
-Genetics Ark requires environment variables in a `.env` file kept in the same directory as your docker-compose.yml file. See the example.env.
+Genetics Ark requires 2 local files containing environment variables:
+- A small `.env` file, kept in the same directory as your docker-compose.yml file. This only contains paths to mounted volumes, plus the path to the main config.txt file, given by GA_CONFIG_PATH. By adjusting this, the user can change their main config path for the docker-compose.yml without having to edit the docker-compose.yml directly. See the example.env.
+- A 'config.txt' file, which contains the majority of the environment variables. See example.config.txt for annotations.
   
 
 ### docker-compose

--- a/web.Dockerfile
+++ b/web.Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.8
 
 RUN apt-get update -y
-RUN apt-get install -y build-essential gcc python3-dev libldap2-dev libsasl2-dev ldap-utils tox lcov valgrind vim nano jq
+RUN apt-get install -y build-essential gcc python3-dev libldap2-dev libsasl2-dev ldap-utils tox lcov valgrind vim nano jq procps
 
 WORKDIR /home/ga
 

--- a/web.Dockerfile
+++ b/web.Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.8
 
 RUN apt-get update -y
-RUN apt-get install -y build-essential gcc python3-dev libldap2-dev libsasl2-dev ldap-utils tox lcov valgrind
+RUN apt-get install -y build-essential gcc python3-dev libldap2-dev libsasl2-dev ldap-utils tox lcov valgrind vim nano jq
 
 WORKDIR /home/ga
 


### PR DESCRIPTION
Updated the docker-compose.yml so that it acts as a back-up file. Parameterised more of docker-compose.yml for portability.
Installed nano and jq in the web container, for easier troubleshooting.
closes #74 
closes #71 

Test set-up
- Edited the docker-compose.yml, config file, and env file in the development environment, to match the same format as in GitHub
- Set up a .env file on my local laptop and used 'docker compose build' to make test images, which should incorporate jq and nano into the genetics-ark-web container. Retagged the new images to 'update_compose'.
- Saved the test web image as a file, file-GkjZF1Q4J91vyF72xg08JXvK, copied it to the development environment, and loaded the image from the file.
- Edited the development 'docker-compose.yml' to use the test-tagged versions of 'genetics-ark-web:update_compose' and 'genetics-ark-cron:issue_70', instead of the last release, 2.0.3
- Ran the docker-compose.yml to start Genetics Ark
- Exec'd into the cron job container to run the updater automatically


Test results
- When exec'd into the web container, jq gives help information, and nano opens an editor with 'Welcome to nano', rather than throwing errors about the tools not being found
- Genetics Ark front page shows on dev without nginx errors
- The Service Desk link-out works
- Primer Designer:
	Produces an output PDF with a straightforward example
	Reference files, primer version, e.t.c (annotated from config) in the metadata section at the bottom of the PDF look normal
- IGV:
	Logs in normally
	Sample search for '101' returns a list of results
	Able to open and view IGV in browser for a recent sample

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/Genetics_Ark/77)
<!-- Reviewable:end -->
