### PR TITLE
Speed up dx

### DIFF
--- a/cron/find_dx_data.py
+++ b/cron/find_dx_data.py
@@ -231,7 +231,9 @@ def find_dx_bams(project_id_to_name: dict) -> None:
     bams_idxs = find_in_parallel_multiproject(
         list(project_id_to_name.keys()), "^.*\.bam$|^.*\.bai$"
     )
-    grouped_bam_idxs = {k: list(v) for k, v in groupby(bams_idxs, lambda x: x['project'])}
+    grouped_bam_idxs = {
+        k: list(v) for k, v in groupby(bams_idxs, lambda x: x["project"])
+    }
 
     for project_id, project_name in project_id_to_name.items():
         bam_dict = {}
@@ -240,8 +242,16 @@ def find_dx_bams(project_id_to_name: dict) -> None:
         # get project-relevant data, split by bam and bai
         project_info = grouped_bam_idxs.get(project_id)
         if project_info:
-            project_bams = [x for x in project_info if x["describe"]["name"].endswith(".bam")]
-            project_idxs = [x for x in project_info if x["describe"]["name"].endswith(".bai")]
+            project_bams = [
+                x
+                for x in project_info
+                if x["describe"]["name"].endswith(".bam")
+            ]
+            project_idxs = [
+                x
+                for x in project_info
+                if x["describe"]["name"].endswith(".bai")
+            ]
 
         if project_bams and project_idxs:
             # if BAM(s) and index found for the project,

--- a/cron/find_dx_data.py
+++ b/cron/find_dx_data.py
@@ -345,27 +345,19 @@ def find_cnvs(data_dict: dict):
 
     project_name = dx.DXProject(PROJECT_CNVS).describe()["name"]
 
-    beds = list(
+    # combine into one API call for speed
+    beds_indices = list(
         dx.search.find_data_objects(
             project=PROJECT_CNVS,
-            name=".*_copy_ratios.gcnv.bed.gz\Z",
+            name=".*_copy_ratios.gcnv.bed.gz\Z|.*_copy_ratios.gcnv.bed.gz.tbi\Z",
             name_mode="regexp",
             describe={
                 "fields": {"folder": True, "name": True, "archivalState": True}
             },
         )
     )
-
-    indices = list(
-        dx.search.find_data_objects(
-            project=PROJECT_CNVS,
-            name=".*_copy_ratios.gcnv.bed.gz.tbi\Z",
-            name_mode="regexp",
-            describe={
-                "fields": {"folder": True, "name": True, "archivalState": True}
-            },
-        )
-    )
+    beds = [x for x in beds_indices if x["describe"]["name"].endswith(".gz")]
+    indices = [x for x in beds_indices if x["describe"]["name"].endswith(".tbi")]
 
     for file in beds:
         cnv_name = file["describe"]["name"]

--- a/cron/find_dx_data.py
+++ b/cron/find_dx_data.py
@@ -356,7 +356,11 @@ def find_cnvs(data_dict: dict):
                 if index_file["describe"]["name"] == f"{cnv_name}.tbi":
                     cnv_index.append(index_file)
 
-        if len(cnv_index) == 1:
+        if len(cnv_index):
+            if len(cnv_index) > 1:
+                # very occasionally there's more than one index file
+                # try the first (error will happen if unlucky)
+                print(f"Multiple index files found for {cnv_name} - using the first only")
             cnv_index = cnv_index[0]
             cnv_dict["idx_name"] = cnv_index["describe"]["name"]
             cnv_dict["idx_id"] = cnv_index["id"]
@@ -365,8 +369,6 @@ def find_cnvs(data_dict: dict):
                 "archivalState"
             ]
         else:
-            if len(cnv_index) > 1:
-                print(f"Multiple index files found for {cnv_name} - returning no index results")
             cnv_dict["idx_name"] = None
             cnv_dict["idx_id"] = None
             cnv_dict["idx_path"] = None

--- a/cron/find_dx_data.py
+++ b/cron/find_dx_data.py
@@ -140,15 +140,11 @@ def get_002_projects() -> dict:
 
     return project_id_to_name
 
-
 def find_in_parallel_multiproject(projects, search_term) -> list:
     """
     Parallel search across multiple named project, adapted from dias report bulk reanalyser.
 
     Call dxpy.find_data_objects in parallel.
-
-    Projects are chunked into max 100 items and queried in one
-    go as a regex pattern for more efficient querying
 
     Parameters
     ----------
@@ -182,12 +178,9 @@ def find_in_parallel_multiproject(projects, search_term) -> list:
 
     results = []
 
-    # create chunks of 100 projects from list for querying
-    chunked_projects = [projects[i:i + 100] for i in range(0, len(projects), 100)]
-
     with concurrent.futures.ThreadPoolExecutor(max_workers=32) as executor:
         concurrent_jobs = {
-            executor.submit(_find, project, search_term) for project in chunked_projects
+            executor.submit(_find, project, search_term) for project in projects
         }
 
         for future in concurrent.futures.as_completed(concurrent_jobs):
@@ -229,6 +222,7 @@ def find_dx_bams(project_id_to_name: dict) -> None:
     missing_bam = defaultdict(list)
 
     # loop through proj to get bam file in each of them
+    #TODO: compare bam and bai calls, fix the results with list comprehensions
     bams = find_in_parallel_multiproject(list(project_id_to_name.keys()), "*bam")
     idxs = find_in_parallel_multiproject(list(project_id_to_name.keys()), "*bam.bai")
 

--- a/cron/find_dx_data.py
+++ b/cron/find_dx_data.py
@@ -164,8 +164,8 @@ def find_in_parallel_multiproject(projects, search_term) -> list:
         """
         return list(dx.find_data_objects(
             project=project,
-            name=search_term,
-            name_mode='glob',
+            name=rf'{search_term}',
+            name_mode='regexp',
             describe={
                 'fields': {
                     'name': True,
@@ -222,9 +222,9 @@ def find_dx_bams(project_id_to_name: dict) -> None:
     missing_bam = defaultdict(list)
 
     # loop through proj to get bam file in each of them
-    #TODO: compare bam and bai calls, fix the results with list comprehensions
-    bams = find_in_parallel_multiproject(list(project_id_to_name.keys()), "*bam")
-    idxs = find_in_parallel_multiproject(list(project_id_to_name.keys()), "*bam.bai")
+    bams_idxs = find_in_parallel_multiproject(list(project_id_to_name.keys()), "^.*\.bam$|^.*\.bai$")
+    bams = [x for x in bams_idxs if x["describe"]["name"].endswith(".bam")]
+    idxs = [x for x in bams_idxs if x["describe"]["name"].endswith(".bai")]
 
     for project_id, project_name in project_id_to_name.items():
         bam_dict = {}
@@ -390,7 +390,7 @@ def find_cnvs(data_dict: dict):
                 if index_file["describe"]["name"] == f"{cnv_name}.tbi":
                     cnv_index.append(index_file)
 
-        if len(cnv_index):
+        if cnv_index:
             if len(cnv_index) > 1:
                 # very occasionally there's more than one index file
                 # try the first (error will happen if unlucky)

--- a/cron/find_dx_data.py
+++ b/cron/find_dx_data.py
@@ -229,8 +229,8 @@ def find_dx_bams(project_id_to_name: dict) -> None:
     missing_bam = defaultdict(list)
 
     # loop through proj to get bam file in each of them
-    bams = find_in_parallel_multiproject(project_id_to_name.keys(), "*bam")
-    idxs = find_in_parallel_multiproject(project_id_to_name.keys(), "*bam.bai")
+    bams = find_in_parallel_multiproject(list(project_id_to_name.keys()), "*bam")
+    idxs = find_in_parallel_multiproject(list(project_id_to_name.keys()), "*bam.bai")
 
     for project_id, project_name in project_id_to_name.items():
         bam_dict = {}

--- a/cron/find_dx_data.py
+++ b/cron/find_dx_data.py
@@ -122,14 +122,18 @@ def get_002_projects() -> dict:
     project_id_to_name = {
         project["id"]: project["describe"]["name"]
         for project in dx.search.find_projects(
-            name="002*", name_mode="glob", describe={"fields": {"name": True}}
+            name="002*",
+            name_mode="glob",
+            describe={"fields": {"name": True}}
         )
     }
 
     # might return multiple results as it's searched by name
     for development_project in dx.search.find_projects(
-        name=DEV_PROJECT_NAME, name_mode="glob"
-    ):
+        name=DEV_PROJECT_NAME,
+        name_mode="glob", 
+        describe={'fields':{'folder':True, 'name': True, 'archivalState': True}},
+        ):
         project_id_to_name[development_project["id"]] = DEV_PROJECT_NAME
 
     print("Total 002 projects found:", len(project_id_to_name))


### PR DESCRIPTION
Changes:
Parallelising dxpy searches and removing redundant API calls
Closes #73 #62 

Test set-up:
Ran latest-version genetics-ark-cron code (with jq manually installed), and looked at outputs of the find_dx_data.py
Compared to the output from find_dx_data.py when running genetics-ark-cron:speed_up_dx, keeping the rest of the containers the same.

Test results:
Updated code runs 10x faster (on comparison run, 65.9 seconds versus 1100.8 seconds)
Nothing gets output to the cron error logs
Both the updated code and the current code, find the same number of file entries (cat dx_002_bams.json | jq '.BAM[][].idx_name' | wc), and no empty indices with 'jq '.BAM[][].idx_name''
The dx_002_bams.json file is the same size for updated and current code. dx_missing_bam.json is trivially different (584623 for new, 584149 for old).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/Genetics_Ark/78)
<!-- Reviewable:end -->
