### PR TITLE
Add komodo monitoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ staticfiles
 reference
 .vscode
 .DS_Store
+*.gz
+*/*.gz

--- a/cron/Dockerfile
+++ b/cron/Dockerfile
@@ -3,7 +3,6 @@ FROM python:3.8-slim
 RUN apt-get update && apt-get -y install -qq --force-yes cron
 RUN apt-get -y install vim nano jq procps
 RUN apt-get install gcc python3-dev -y
-RUN apt-get -y install podman
 
 WORKDIR /home
 

--- a/cron/Dockerfile
+++ b/cron/Dockerfile
@@ -3,6 +3,7 @@ FROM python:3.8-slim
 RUN apt-get update && apt-get -y install -qq --force-yes cron
 RUN apt-get -y install vim
 RUN apt-get install gcc python3-dev -y
+RUN apt-get -y install podman
 
 WORKDIR /home
 

--- a/cron/Dockerfile
+++ b/cron/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get install gcc python3-dev -y
 
 WORKDIR /home
 
-ENV PYTHONUNBUFFERED 1
+ENV PYTHONUNBUFFERED="1"
 
 COPY requirements.txt find_dx_data.py ./
 

--- a/cron/Dockerfile
+++ b/cron/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /home
 
 ENV PYTHONUNBUFFERED="1"
 
-COPY requirements.txt find_dx_data.py ./
+COPY requirements.txt find_dx_data.py emit_prom_metric.py ./
 
 RUN pip install -r requirements.txt
 

--- a/cron/crontab
+++ b/cron/crontab
@@ -1,4 +1,4 @@
 # start cron
 0 2 * * * rm -rf /home/tmp/* && echo "`date +\%Y\%m\%d-\%H:\%M:\%S` tmp folder cleared" >> /home/log/ga-cron.log 2>&1
-0 2 * * * /usr/local/bin/python -u /home/find_dx_data.py >> /home/log/ga-cron.log 2>&1 && echo "`date +\%Y\%m\%d-\%H:\%M:\%S` sample file updated" >> /home/log/ga-cron.log 2>&1
+0 2 * * * /usr/local/bin/python -u /home/find_dx_data.py >> /home/log/ga-cron.log 2>&1 && echo "`date +\%Y\%m\%d-\%H:\%M:\%S` sample file updated" >> /home/log/ga-cron.log 2>&1 && docker run --rm -v /home/log:/prom_metrics komodo_cron_metrics.v1.0.0 genetics_ark
 # end cron

--- a/cron/crontab
+++ b/cron/crontab
@@ -1,4 +1,4 @@
 # start cron
-0 2 * * * rm -rf /home/tmp/* && echo "`date +\%Y\%m\%d-\%H:\%M:\%S` tmp folder cleared" >> /home/log/ga-cron.log 2>&1
-0 2 * * * /usr/local/bin/python -u /home/find_dx_data.py >> /home/log/ga-cron.log 2>&1 && echo "`date +\%Y\%m\%d-\%H:\%M:\%S` sample file updated" >> /home/log/ga-cron.log 2>&1 && podman run --rm -v /home/log:/prom_metrics komodo_cron_metrics.v1.0.0 genetics_ark
+0 2 * * * rm -rf /home/tmp/* && echo "`date +\%Y\%m\%d-\%H:\%M:\%S` tmp folder cleared" >> /home/log/ga-cron.log 2>&1 && echo "`date +\%Y\%m\%d-\%H:\%M:\%S` sample file updated" >> /home/log/ga-cron.log 2>&1 && /usr/local/bin/python -u /home/emit_prom_metric.py "ga_temp_deleted"
+*/15 * * * * /usr/local/bin/python -u /home/find_dx_data.py >> /home/log/ga-cron.log 2>&1 && echo "`date +\%Y\%m\%d-\%H:\%M:\%S` sample file updated" >> /home/log/ga-cron.log 2>&1 && /usr/local/bin/python -u /home/emit_prom_metric.py "ga_cron_completed"
 # end cron

--- a/cron/crontab
+++ b/cron/crontab
@@ -1,4 +1,4 @@
 # start cron
 0 2 * * * rm -rf /home/tmp/* && echo "`date +\%Y\%m\%d-\%H:\%M:\%S` tmp folder cleared" >> /home/log/ga-cron.log 2>&1
-0 2 * * * /usr/local/bin/python -u /home/find_dx_data.py >> /home/log/ga-cron.log 2>&1 && echo "`date +\%Y\%m\%d-\%H:\%M:\%S` sample file updated" >> /home/log/ga-cron.log 2>&1 && docker run --rm -v /home/log:/prom_metrics komodo_cron_metrics.v1.0.0 genetics_ark
+0 2 * * * /usr/local/bin/python -u /home/find_dx_data.py >> /home/log/ga-cron.log 2>&1 && echo "`date +\%Y\%m\%d-\%H:\%M:\%S` sample file updated" >> /home/log/ga-cron.log 2>&1 && podman run --rm -v /home/log:/prom_metrics komodo_cron_metrics.v1.0.0 genetics_ark
 # end cron

--- a/cron/emit_prom_metric.py
+++ b/cron/emit_prom_metric.py
@@ -1,0 +1,81 @@
+import argparse
+import datetime as date
+import glob
+from pathlib import Path
+import os
+
+def get_args():
+    """
+    Parse the logging path and the job name
+    """
+    args = argparse.ArgumentParser()
+    args.add_argument(
+        "job_name",
+        type=str,
+        help="A string to represent the job name in Grafana. This must"
+        " match the requirements of the Prometheus data model.",
+    )
+    return args.parse_args()
+
+
+class Prometheus:
+    """
+    A class for formatting and writing logs which are readible by Prometheus
+    monitoring software. Currently this only logs a 'job completed' message.
+    """
+
+    def __init__(
+        self,
+        out_path: str,
+        jobname: str,
+    ):
+        self.out_path = out_path
+        self.jobname = jobname
+        self.metrics = []
+        self.ppid = os.getppid()
+        self.error_filename = f"{self.out_path}/{str(date.datetime.now())}.err"
+        self.temp_filename = f"{self.out_path}/{self.jobname}.prom.{self.ppid}"
+
+    def format_metrics(self) -> None:
+        """
+        Formats a Prometheus-compatible 'job completed' metric.
+        Adds it to a list of ready-to-write metrics.
+        """
+        timestamp = int(round(date.datetime.now().timestamp()))
+        completed_metric = f"{self.jobname} {timestamp}"
+        self.metrics.append(completed_metric)
+
+    def emit_temp_metrics(self) -> None:
+        """
+        Saves the Prometheus metrics to a temporary output prom file.
+        """
+        # write metric to a temporary path
+        with open(self.temp_filename, "a") as new_file:
+            for metric in self.metrics:
+                new_file.write(metric + "\n")
+
+    def replace_old_metrics(self) -> None:
+        """
+        Handles the deletion of older metrics ending in *.prom, to prevent
+        interference with logging. Renames new metric and sets permissions.
+        """
+        old_files = glob.glob(f"{self.out_path}/{self.jobname}*.prom")
+        if old_files:
+            for file in old_files:
+                Path(file).unlink()
+
+        new_filename = Path(f"{self.out_path}/{self.jobname}.prom")
+        Path(self.temp_filename).rename(new_filename)
+        os.chmod(new_filename, int("644", base=8))
+
+
+def main():
+    args = get_args()
+    prom = Prometheus("/home/log", args.job_name)
+    prom.format_metrics()
+    prom.emit_temp_metrics()
+    prom.replace_old_metrics()
+
+
+if __name__ == "__main__":
+    main()

--- a/cron/emit_prom_metric.py
+++ b/cron/emit_prom_metric.py
@@ -4,6 +4,7 @@ import glob
 from pathlib import Path
 import os
 
+
 def get_args():
     """
     Parse the logging path and the job name

--- a/cron/find_dx_data.py
+++ b/cron/find_dx_data.py
@@ -385,7 +385,7 @@ def find_cnvs(data_dict: dict):
         cnv_path = file["describe"]["folder"]
         cnv_id = file["id"]
         cnv_archival_status = file["describe"]["archivalState"]
-        
+
         cnv_dict = {
             "file_name": cnv_name,
             "file_id": cnv_id,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ version: '2.6'
 services:
   geneticsweb:
     container_name: genetics-ark-web
-    image: genetics-ark-web:2.0.1
+    image: genetics-ark-web:2.0.3
     platform: linux/amd64
     build:
       dockerfile: web.Dockerfile
@@ -24,7 +24,7 @@ services:
       - geneticsdb
   geneticscron:
     container_name: genetics-ark-cron
-    image: genetics-ark-cron:2.0.1
+    image: genetics-ark-cron:add_komodo_monitoring
     platform: linux/amd64
     restart: always
     build: ./cron
@@ -61,7 +61,7 @@ services:
     ports:
       - 6379:6379
   geneticsdjangoq:
-    image: genetics-ark-djangoq:2.0.1
+    image: genetics-ark-djangoq:2.0.3
     platform: linux/amd64
     container_name: genetics-ark-djangoq
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,8 +58,6 @@ services:
     image: genetics-ark-djangoq:2.0.3
     platform: linux/amd64
     container_name: genetics-ark-djangoq
-    image: genetics-ark-djangoq:2.0.3
-    platform: linux/amd64
     build:
       dockerfile: primer.Dockerfile
     command: python manage.py qcluster

--- a/komodo_cron_metrics.Dockerfile
+++ b/komodo_cron_metrics.Dockerfile
@@ -1,0 +1,2 @@
+FROM komodo-cron-metrics:v1.0.0
+

--- a/readme.md
+++ b/readme.md
@@ -31,8 +31,8 @@ In addition, you'll need to check that nginx/nginx.conf displays the correct por
 
 #### cron
 - By default, find_dx_data.py runs every 15 minutes, and checks for new samples in DNAnexus which can be made available to IGV. A script which clears out a temporary directory runs every morning at 2am.
-- Both the above cron jobs, on successful completion, emit text log files plus Prometheus-formatted metric files.
-- Edit `crontab` file to tweak cron schedule.
+- Both the above cron jobs, on successful completion, emit text log files plus Prometheus-formatted metric files. The metrics can be used with Prometheus to send alerts, if they do not run when expected.
+- Edit the `crontab` file to tweak the cron schedule.
 ```
 # start cron
 0 2 * * * rm -rf /home/tmp/* && echo "`date +\%Y\%m\%d-\%H:\%M:\%S` tmp folder cleared" >> /home/log/ga-cron.log 2>&1 && echo "`date +\%Y\%m\%d-\%H:\%M:\%S` sample file updated" >> /home/log/ga-cron.log 2>&1 && /usr/local/bin/python -u /home/emit_prom_metric.py "ga_temp_deleted"

--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,7 @@ Genetics Ark is a Django based web interface for hosting apps used by clinical s
 - reference files for IGV.js (fasta, fai, cytoband, refseq)
 - Docker & Docker Compose
 - [Primer Designer](https://github.com/eastgenomics/primer_designer) (deployed on Docker)
+- [Komodo Cron Metrics](https://github.com/eastgenomics/komodo_cron_metrics) (deployed on Docker)
 
 #### primer designer
 Genetics Ark allows primer input submission: `<chromosome>:<position> <genome build>`
@@ -31,12 +32,13 @@ Edit `env_file` in `docker-compose.yml` to point to your `.env` file
 ```
 # start cron
 0 2 * * * rm -rf /home/tmp/* && echo "`date +\%Y\%m\%d-\%H:\%M:\%S` tmp folder cleared" >> /home/log/ga-cron.log 2>&1
-0 2 * * * /usr/local/bin/python -u /home/find_dx_data.py >> /home/log/ga-cron.log 2>&1
+0 2 * * * /usr/local/bin/python -u /home/find_dx_data.py >> /home/log/ga-cron.log 2>&1 && echo "`date +\%Y\%m\%d-\%H:\%M:\%S` sample file updated" >> /home/log/ga-cron.log 2>&1 && docker run --rm -v /home/log:/prom_metrics komodo_cron_metrics.v1.0.0 genetics_ark
 # end cron
 ```
 Check schduled cron is running by accessing cron container `docker exec -it <container id> bash` then `crontab -l`. Sometimes cron ran into [pam security issue](https://stackoverflow.com/questions/21926465/issues-running-cron-in-docker-on-different-hosts). 
 
-All cron run log will be stored in cron container `/home/log/cron.log`
+All plain text cron run logs will be stored in the cron container `/home/log/cron.log`
+Prometheus-formatted completion time logs are also produced. They will be stored in the same directory and are named with the '.prom' suffix: `/home/log/*.prom`
 
 ### Running in local system
 - change logging location in `ga_core/settings.py`


### PR DESCRIPTION
# Changes
Added code to write out Prometheus-compatible metrics when cron jobs run.

# Setting up and running tests
1. Made Docker image for genetics-ark-cron and transferred to dev environment
2. Ran podman-compose with this test cron image
3. Exec'd into the cron container, /bin/sh
4. Ran the cron job commands manually 

# Outcome
When the commands were manually run, a ga_cron_completed metric and a ga_temp_deleted metric, both with timestamps, were written to logs
The ga_cron_completed metric (which has monitoring on it) gets successfully displayed in the development version of the komodo-monitor monitoring dashboard
Running the command a second time produced a new text file, and deleted the old copy of the same file
The find_dx_data.py command was observed running as a cron job and writing out a *.prom file, at 00 minutes past the hour.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/Genetics_Ark/81)
<!-- Reviewable:end -->
