### PR TITLE
Change ldap filter

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,3 +16,8 @@ app/*/*/*/__pycache__/
 .venv/
 venv/
 reference
+
+# Images that were saved to file already
+*.tar
+*.gz
+*.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ reference
 .vscode
 .DS_Store
 # avoid incorporating zipped Docker image files
+*.tar
 *.gz
 */*.gz
 config.dev.txt

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -38,7 +38,7 @@ def login_action(request):
         else:
             context_dict["error"] = True
 
-            messages.add_message(request, messages.ERROR, "Incorrect Login Credential")
+            messages.add_message(request, messages.ERROR, "Username or password incorrect")
             return render(request, "registration/login.html", context_dict)
     else:
         return render(request, "registration/login.html", context_dict)

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -38,7 +38,9 @@ def login_action(request):
         else:
             context_dict["error"] = True
 
-            messages.add_message(request, messages.ERROR, "Username or password incorrect")
+            messages.add_message(
+                request, messages.ERROR,"Username or password incorrect"
+                )
             return render(request, "registration/login.html", context_dict)
     else:
         return render(request, "registration/login.html", context_dict)

--- a/example.config.txt
+++ b/example.config.txt
@@ -34,11 +34,14 @@ PRIMER_DOWNLOAD=http://localhost:80/genetics_ark
 
 
 # Variables for authorising log-ins using LDAP. LDAP_CONF is the base DN. 
+# LDAP_PERMITTED_GROUP restricts authentication to a named group
 
 BIND_DN=
 BIND_PASSWORD=
 AUTH_LDAP_SERVER_URI=
 LDAP_CONF=
+LDAP_PERMITTED_GROUP=
+
 
 
 # Variables for the GA database

--- a/ga_core/settings.py
+++ b/ga_core/settings.py
@@ -111,6 +111,8 @@ INSTALLED_APPS = [
     "crispy_bootstrap5",
     "user_visit",
     "django_q",
+    # just useful
+    "debug_toolbar",
 ]
 
 # Django crispy forms bootstrap configuration
@@ -213,8 +215,6 @@ AUTH_LDAP_CONNECTION_OPTIONS = {ldap.OPT_REFERRALS: 0}
 AUTH_LDAP_USER_SEARCH = LDAPSearch(
     LDAP_CONF, ldap.SCOPE_SUBTREE, "(samaccountname=%(user)s)"
 )
-
-LDAPSearch("dc=net,dc=addenbrookes,dc=nhs,dc=uk", ldap.SCOPE_SUBTREE, "(uid=%(user)s)")
 
 AUTH_LDAP_GROUP_SEARCH = LDAPSearch(
     LDAP_PERMITTED_GROUP,

--- a/ga_core/settings.py
+++ b/ga_core/settings.py
@@ -8,7 +8,7 @@ from django.contrib.messages import constants
 from dotenv import load_dotenv
 
 import ldap
-from django_auth_ldap.config import LDAPSearch
+from django_auth_ldap.config import LDAPSearch, LDAPGroupQuery
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -74,12 +74,19 @@ try:
 
     AUTH_LDAP_SERVER_URI = os.environ["AUTH_LDAP_SERVER_URI"]
     LDAP_CONF = os.environ["LDAP_CONF"]
+    LDAP_PERMITTED_GROUP = os.environ["LDAP_PERMITTED_GROUP"]
+
 except KeyError as e:
     key = e.args[0]
     raise KeyError(
         f"Unable to import {key} from environment, is an .env file "
         "present or env variables set?"
     )
+
+# load up LDAP user groups, and restrict access to the named group given
+# in the config file
+AUTH_LDAP_FIND_GROUP_PERMS = True
+AUTH_LDAP_REQUIRE_GROUP = LDAPGroupQuery(LDAP_PERMITTED_GROUP)
 
 
 if DEBUG:

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ Django==4.2
 django-auth-ldap==4.8.0
 django-cors-headers==3.14.0
 django-crispy-forms==2.0
+django-debug-toolbar==4.3.0
 django-picklefield==3.1
 django-q==1.3.9
 django-user-visit==1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ click==8.1.3
 crispy-bootstrap5==0.7
 cryptography==36.0.2
 Django==4.2
-django-auth-ldap==4.2.0
+django-auth-ldap==4.8.0
 django-cors-headers==3.14.0
 django-crispy-forms==2.0
 django-picklefield==3.1


### PR DESCRIPTION
Logging in can now be restricted to members of a config-specified LDAP group.
This affects the IGV section of Genetics Ark.

Test that authorisation passes, if I am in the correct LDAP group:
- Set up: provide the correct LDAP_PERMITTED_GROUP in the config
- Test: Log in to Genetics Ark using my credentials
- Result: Log in succeeds, and I am able to access IGV and view data

Test that authorisation fails, if I am not in the correct group:
- Set up: deliberately provide an incorrect LDAP_PERMITTED_GROUP string in the config (it starts with LDAP_PERMITTED_GROUP=cn=GA Test,ou=GA Test and is in the LDAP_CONF scope)
- Test: Log in to Genetics Ark using my credentials
- Result: I get an error message in the website log-in page, telling me that log-in has failed. In the genetics-ark-web logs, I get the debug message: 'DEBUG 2024-07-24 13:26:07,283 django_auth_ldap Authentication failed for <redacted>: user does not satisfy AUTH_LDAP_REQUIRE_GROUP'
- So, authentication successfully block users who aren't in the config's LDAP_PERMITTED_GROUP

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/Genetics_Ark/82)
<!-- Reviewable:end -->
