### PR TITLE
Handle sp prefix

### DIFF
--- a/DNAnexus_to_igv/views.py
+++ b/DNAnexus_to_igv/views.py
@@ -175,8 +175,8 @@ def sanitize_sample_id(original):
         - sample_id (str): sample ID after sanitizing
     """
     sample_id = str(original).strip()
-    if sample_id.startswith("SP_"):
-        sample_id = sample_id.replace("SP_", "")
+    if sample_id.startswith("SP-"):
+        sample_id = sample_id.replace("SP-", "")
     return sample_id
 
 @login_required()

--- a/DNAnexus_to_igv/views.py
+++ b/DNAnexus_to_igv/views.py
@@ -164,6 +164,20 @@ def get_dx_urls(
             "error": msg
         }
 
+def sanitize_sample_id(original):
+    """
+    Strip out spaces from the sample ID entered by the user, and if the sample
+    begins with 'SP-', remove this.
+
+    Args:
+        - original (str): sample ID as retrieved from the search form
+    Returns:
+        - sample_id (str): sample ID after sanitizing
+    """
+    sample_id = str(original).strip()
+    if sample_id.startswith("SP_"):
+        sample_id = sample_id.replace("SP_", "")
+    return sample_id
 
 @login_required()
 def index(request):
@@ -190,8 +204,8 @@ def search(request):
         context_dict["url_form"] = UrlForm()
         context_dict["desk"] = GRID_SERVICE_DESK
 
-        sample_id = request.POST["sample_id"]
-        sample_id = str(sample_id).strip()  # in case spaces
+        entered_sample_id = request.POST["sample_id"]
+        sample_id = sanitize_sample_id(entered_sample_id)
 
         try:
             # load in json with all bams and dx attributes needed to
@@ -246,7 +260,7 @@ def search(request):
                     or some other error. <br/>Please contact\
                     the Bioinformatics team if you believe the sample\
                     should be available.""".format(
-                        sample_id
+                        entered_sample_id
                     )
                 ),
                 extra_tags="alert-danger",
@@ -260,7 +274,7 @@ def search(request):
                         """Sample {} not found in JSON. Either sample
                 name mistyped or an error in finding the BAMs for the
                 sample, possibly missing index.""".format(
-                            sample_id
+                            entered_sample_id
                         ),
                     )
                 )
@@ -300,7 +314,7 @@ def search(request):
                     messages.ERROR,
                     mark_safe(
                         "Error generating download URLs for sample "
-                        f"{sample_id}.<br/>Please contact the bioinformatics "
+                        f"{entered_sample_id}.<br/>Please contact the bioinformatics "
                         f"team for help.<br/>File Error Message: {file_error}"
                         f"<br/>Index Error Message: {idx_error}"
                     ),
@@ -309,7 +323,7 @@ def search(request):
                 context_dict["error"] = True
 
                 logger.error(
-                    f"Error generating url for sample {sample_id} "
+                    f"Error generating url for sample {entered_sample_id} "
                     f"{sample_dict}"
                 )
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,6 +77,7 @@ services:
     container_name: genetics-ark-db
     image: mysql:8
     platform: linux/amd64
+    restart: always
     expose:
       - 3308
     env_file:


### PR DESCRIPTION
# Changes
To close #84 and #85 
Added 'restart: always' to every container in docker-compose.yml
Changed the IGV tool, so that when a user tries to search with a term starting with 'SP-' (note hyphen not underscore), Genetics Ark will remove the 'SP-' before continuing

# Test set up
Make web Docker container
On development environment, run most recent versions of 'main' Docker containers, plus the changed web container
Check website is up and working

# Tests
## Test that a vague search matching many results, will work PASS
Searched for sample '100' and then 'SP-100' for BAMs = get the same number of results
Searched for sample '100' and then 'SP-100' for CNV samples = get the same number of results

This is a pass as SP- is omitted from search. Previously this would've given 'sample not found' errors. 
Note that the results message says '# files found for <sample name with SP- removed>' instead of '# files found for <sample name with SP- still in place>'. We can't decide whether one strategy is better than the other, and changing it would double the work involved, so in the interest of time we're leaving it.

## Test that a non-existent number throws errors in each case PASS
Search for a fake number, BAM - 'Sample not found' error
Search for a fake number, CNV - 'Sample not found' error
Search for a fake number starting with SP-, BAM - 'Sample (with SP- removed) not found' error
Search for a fake number starting with SP-, CNV - 'Sample (with SP- removed) not found' error

This is a pass. SP- is removed for the search, but we leave it in for the error message shown to the scientist.

## Test that SP- search results behave normally when you click on them PASS
The result is opened, and can be viewed in IGV as usual.
It says 'Search term:' with the SP- omitted underneath.